### PR TITLE
📈 GA計測の追加

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -9,9 +9,13 @@ name: Deploy to Firebase Hosting on merge
 jobs:
   build_and_deploy:
     runs-on: ubuntu-latest
+    environment: production
     steps:
       - uses: actions/checkout@v2
-      - run: yarn && yarn build
+      - name: build
+        env:
+          NEXT_PUBLIC_GOOGLE_ANALYTICS_ID: "${{ secrets.NEXT_PUBLIC_GOOGLE_ANALYTICS_ID }}"
+        run: yarn && yarn build
       - uses: FirebaseExtended/action-hosting-deploy@v0
         with:
           repoToken: "${{ secrets.GITHUB_TOKEN }}"

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   },
   "devDependencies": {
     "@svgr/webpack": "^5.5.0",
+    "@types/gtag.js": "^0.0.8",
     "@types/node": "16.11.6",
     "@types/react": "17.0.34",
     "eslint": "7",

--- a/src/lib/gtag.ts
+++ b/src/lib/gtag.ts
@@ -1,0 +1,28 @@
+// ない場合でも型をstringにする
+export const GA_TRACKING_ID: string = process.env.NEXT_PUBLIC_GOOGLE_ANALYTICS_ID || "";
+
+// https://developers.google.com/analytics/devguides/collection/gtagjs/pages
+export const pageview = (url: string): void => {
+  window.gtag("config", GA_TRACKING_ID, {
+    page_path: url,
+  });
+};
+
+// https://developers.google.com/analytics/devguides/collection/gtagjs/events
+export const event = ({
+  action,
+  category,
+  label,
+  value = "",
+}: {
+  action: string;
+  category: string;
+  label: string;
+  value?: string;
+}): void => {
+  window.gtag("event", action, {
+    event_category: category,
+    event_label: JSON.stringify(label),
+    value,
+  });
+};

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,14 +1,46 @@
 import type { AppProps } from "next/app";
+import { useRouter } from "next/router";
+import Script from "next/script";
+import { useEffect } from "react";
 import { ChakraProvider } from "@chakra-ui/react";
+import * as gtag from "../lib/gtag";
 
 import Header from "@/components/Header";
 
 const MyApp = ({ Component, pageProps }: AppProps) => {
+  const router = useRouter();
+  useEffect(() => {
+    const handlerRouteChange = (path: string) => {
+      gtag.pageview(path);
+    };
+    router.events.on("routeChangeComplete", handlerRouteChange);
+    return () => {
+      router.events.off("routeChangeComplete", handlerRouteChange);
+    };
+  }, [router.events]);
+
   return (
-    <ChakraProvider>
-      <Header />
-      <Component {...pageProps} />
-    </ChakraProvider>
+    <>
+      <Script
+        defer
+        src={`https://www.googletagmanager.com/gtag/js?id=${gtag.GA_TRACKING_ID}`}
+        strategy="afterInteractive"
+      />
+      <Script id="gtag-init" defer strategy="afterInteractive">
+        {`
+          window.dataLayer = window.dataLayer || [];
+          function gtag(){dataLayer.push(arguments);}
+          gtag('js', new Date());
+          gtag('config', '${gtag.GA_TRACKING_ID}', {
+            page_path: window.location.pathname,
+          });
+        `}
+      </Script>
+      <ChakraProvider>
+        <Header />
+        <Component {...pageProps} />
+      </ChakraProvider>
+    </>
   );
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1948,6 +1948,11 @@
     "@svgr/plugin-svgo" "^5.5.0"
     loader-utils "^2.0.0"
 
+"@types/gtag.js@^0.0.8":
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/@types/gtag.js/-/gtag.js-0.0.8.tgz#43035ab23a06b3bd0b23968c5c4ef000c597ad8a"
+  integrity sha512-xKDygydxruSUNkVbZWjiEbMijz9+xZCLb2yiTiQT88pm5EhIAUhaCo05IZF1HcQc90u4W7cp+7OZNpcJxpyL5g==
+
 "@types/json5@^0.0.29":
   version "0.0.29"
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"


### PR DESCRIPTION
## 作業内容
GAのトラッキングIDを払い出して、まずはページViewのみ計測するようにしました。
Nextjs公式のGAサンプルを参考にしました。
https://github.com/vercel/next.js/tree/master/examples/with-google-analytics

ビルド時に埋め込みたい環境変数は、Github側のEnvironmentに仕込んでいます。
`NEXT_PUBLIC_GOOGLE_ANALYTICS_ID`

## 対応issue
close #17 